### PR TITLE
/bin/bash -> /bin/sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Run this to generate all the initial makefiles, etc.
 
 srcdir=`dirname $0`


### PR DESCRIPTION
Useful for systems that don't have /bin/bash, like NixOS or most of the BSDs.
