### PR TITLE
BudgieMenu: update settings key

### DIFF
--- a/panel/applets/budgie-menu/BudgieMenu.vala
+++ b/panel/applets/budgie-menu/BudgieMenu.vala
@@ -36,7 +36,7 @@ public class BudgieMenuApplet : Arc.Applet
     {
         Object();
 
-        settings = new Settings("com.evolve-os.budgie.panel");
+        settings = new Settings("com.solus-project.arc-panel");
         ksettings = new Settings("org.gnome.mutter");
         settings.changed.connect(on_settings_changed);
         ksettings.changed.connect(on_settings_changed);

--- a/panel/applets/budgie-menu/BudgieMenuWindow.vala
+++ b/panel/applets/budgie-menu/BudgieMenuWindow.vala
@@ -269,7 +269,7 @@ public class BudgieMenuWindow : Gtk.Popover
         border_width = 6;
 
         // Currently just to track usage
-        settings = new Settings("com.evolve-os.budgie.panel");
+        settings = new Settings("com.solus-project.arc-panel");
         icon_size = settings.get_int("menu-icons-size");
 
         // search entry up north


### PR DESCRIPTION
This fixes a startup error after running dconf reset. I'm still working on packaging budgie so I can't say for sure that this is correct, but it looks right..
